### PR TITLE
FEAT - Assets registry

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,8 @@ SHABBY_LIB_SRC = \
 	$(SRC)/core/sprite/animated_sprite.cpp \
 	$(SRC)/scene/scene.cpp \
 	$(SRC)/networking/server.cpp \
-	$(SRC)/networking/network_manager.cpp 
+	$(SRC)/networking/network_manager.cpp \
+	$(SRC)/networking/packet_handler.cpp 
 
 EXAMPLE_SRC = \
 	$(EXAMPLE)/main.cpp \
@@ -33,7 +34,8 @@ SHABBY_LIB_OBJ = \
 	$(BUILD)/core/sprite/animated_sprite.o \
 	$(BUILD)/scene/scene.o \
 	$(BUILD)/networking/server.o \
-	$(BUILD)/networking/network_manager.o 
+	$(BUILD)/networking/network_manager.o \
+	$(BUILD)/networking/packet_handler.o 
 
 
 EXAMPLE_OBJ = \

--- a/example/main.cpp
+++ b/example/main.cpp
@@ -12,6 +12,15 @@ enum class TextureId
 
 int main(int argc, char* argv[]) 
 {
+  auto has_arg = [argc, argv](const char* lo) -> bool 
+  {
+    for (int i = 0; i < argc; i++)
+     if (strcmp(argv[i], lo) == 0)
+      return true; 
+
+    return false;
+  };
+
   engine::EngineConfig config{
     800,
     450,
@@ -20,26 +29,47 @@ int main(int argc, char* argv[])
   };  
 
   if (argc > 1) {
-    if (strcmp(argv[1], "server") == 0)
+    if (has_arg("server"))
      config.mode = engine::SERVER;
-    if (strcmp(argv[1], "client") == 0)
+    if (has_arg("client"))
       config.mode = engine::CLIENT;
   }
 
   engine::Engine engine(config);
-  //
-  // TODO: make this all easier to use for game maker
+
   if (config.mode != engine::SERVER) {
-    engine::AssetRegistry<TextureId> registry;
+    auto& registry = engine.GetAssetRegistry<TextureId>();
     registry.LoadAll(
-        engine::AssetDesc<TextureId> { TextureId::Monkey, "assets/actors/monkey/Idle.png"},
-        engine::AssetDesc<TextureId> { TextureId::Monk, "assets/actors/monk/Idle.png"}
-        );
+        engine::AssetDesc<TextureId> { 
+          TextureId::Monkey, 
+          "assets/actors/monkey/Idle.png",
+          4, 1},
+        engine::AssetDesc<TextureId> { 
+          TextureId::Monk, 
+          "assets/actors/monk/Idle.png",
+          6, 1}
+    );
+
+    engine.SetSpriteFactory<TextureId>(
+      [](
+        engine::AssetRegistry<TextureId>& reg, int texture_id) 
+          -> std::unique_ptr<engine::Sprite> 
+      {
+        const char* path = 
+          reg.GetTexturePath(static_cast<TextureId>(texture_id));
+        int cols = 
+          reg.GetTextureCols(static_cast<TextureId>(texture_id));
+        int rows = 
+          reg.GetTextureRows(static_cast<TextureId>(texture_id));
+        return std::make_unique<engine::AnimatedSprite>(
+            path, cols, rows, 3);
+      }
+    );
 
     auto scene = std::make_unique<game::MainScene>();
     size_t player_id;
 
-    if (argc > 2 && strcmp(argv[2], "2") == 0) {
+    if (has_arg("2")) {
       player_id = scene->AddEntityWithServerId<game::Player>(
           std::make_unique<engine::AnimatedSprite>
           (registry, TextureId::Monkey, 4, 1, 3),
@@ -49,7 +79,6 @@ int main(int argc, char* argv[])
           std::make_unique<engine::AnimatedSprite>
           (registry, TextureId::Monk, 6, 1, 3),
           Vector2{100.0f, 100.0f});
-
     }
 
     engine.SetLocalPlayerId(player_id);

--- a/include/core/assets/assets_registry.h
+++ b/include/core/assets/assets_registry.h
@@ -12,6 +12,15 @@ template<typename T>
 struct AssetDesc {
   T id;
   const char* path;
+  int cols = 0;
+  int rows = 0;
+};
+
+struct TextureDesc {
+  Texture2D texture;
+  const char* path;
+  int cols;
+  int rows;
 };
 
 template<typename T>
@@ -26,22 +35,35 @@ public:
 
   Texture2D GetTexture(T id) const
   {
-    return _textures.at(static_cast<int>(id)); 
+    return _textures.at(static_cast<int>(id)).texture; 
   }
 
   const char* GetTexturePath(T id) const
   {
-    return _textures_path.at(static_cast<int>(id)); 
+    return _textures.at(static_cast<int>(id)).path; 
+  }
+
+  int GetTextureCols(T id) const 
+  {
+    return _textures.at(static_cast<int>(id)).cols; 
+  }
+
+  int GetTextureRows(T id) const
+  {
+    return _textures.at(static_cast<int>(id)).rows; 
   }
 private:
-  std::unordered_map<int, Texture2D> _textures;
-  std::unordered_map<int, const char*> _textures_path;
+  std::unordered_map<int, TextureDesc> _textures;
 
   void LoadOne(const AssetDesc<T>& asset)
   {
     int key = static_cast<int>(asset.id); 
-    _textures.emplace(key, LoadTexture(asset.path));
-    _textures_path.emplace(key, asset.path);
+    _textures.emplace(key, TextureDesc{
+        LoadTexture(asset.path), 
+        asset.path,
+        asset.cols,
+        asset.rows
+      });
   }
 };
 

--- a/include/core/factories/sprite_factory.h
+++ b/include/core/factories/sprite_factory.h
@@ -1,0 +1,39 @@
+#ifndef SPRITE_FACTORY_H
+#define SPRITE_FACTORY_H
+
+#include <memory>
+#include <functional>
+#include "core/sprite/sprite.h"
+
+namespace engine {
+
+class SpriteFactory {
+public:
+  SpriteFactory() = default;
+  ~SpriteFactory() = default;
+  
+  void SetFactory(std::function<std::unique_ptr<Sprite>(int)> factory) 
+  {
+    _factory = factory;
+  }
+  
+  std::unique_ptr<Sprite> CreateSprite(int texture_id) const 
+  {
+    if (_factory) {
+      return _factory(texture_id);
+    }
+    return nullptr;
+  }
+  
+  bool IsInitialized() const 
+  {
+    return _factory != nullptr;
+  }
+  
+private:
+  std::function<std::unique_ptr<Sprite>(int)> _factory;
+};
+
+} // namespace engine
+
+#endif // SPRITE_FACTORY_H

--- a/include/core/sprite/animated_sprite.h
+++ b/include/core/sprite/animated_sprite.h
@@ -28,7 +28,7 @@ public:
        int cols,
        int rows,
        float frame_speed)
-  : Sprite(registry.GetTexture(asset_id), registry.GetTexturePath(asset_id)),
+  : Sprite(registry, asset_id),
     _cols(cols),
     _rows(rows),
     _frame_speed(frame_speed),

--- a/include/core/sprite/sprite.h
+++ b/include/core/sprite/sprite.h
@@ -3,6 +3,7 @@
 
 #include <string>
 
+#include "core/assets/assets_registry.h"
 #include "raylib.h"
 
 namespace engine {
@@ -13,6 +14,18 @@ public:
   explicit Sprite(std::string path);
   explicit Sprite(Texture2D texture);
   explicit Sprite(Texture2D texture, const char* path);
+  explicit Sprite(int texture_id);
+
+  template<typename T>
+  explicit Sprite(
+      AssetRegistry<T> registry,
+      T asset_id)
+  : _texture(registry.GetTexture(asset_id)),
+    _texture_id(static_cast<int>(asset_id)),
+    _loaded(true),
+    _path(registry.GetTexturePath(asset_id))
+  {}
+
   virtual ~Sprite(); 
   
   // remove copy
@@ -29,11 +42,13 @@ public:
   virtual void Draw(Rectangle frame_rec, Vector2 pos) const;
 
   const char* GetPath() const;
+  int GetTextureId() const;
 protected:
   const Texture2D& GetTexture() const { return _texture; }
 
 private:
   Texture2D _texture;
+  int _texture_id = 0;
   bool _loaded;
   const char* _path;
 };

--- a/include/entities/entities.h
+++ b/include/entities/entities.h
@@ -32,12 +32,13 @@ public:
   void SetPos(Vector2 p);
   void LoadSprite() const;
   const char* GetSpritePath() const;
+  int GetSpriteTextureId() const;
 private:
   size_t _id;
   std::unique_ptr<Sprite> _sprite;
   int _velocity;
   Vector2 _pos;
-  Client* _client;
+  Client* _client = nullptr;
 };
 
 } // namespace engine

--- a/include/networking/packet_handler.h
+++ b/include/networking/packet_handler.h
@@ -1,0 +1,28 @@
+#ifndef PACKET_HANDLER_H
+#define PACKET_HANDLER_H
+
+#include "networking/packet.h"
+#include "scene/scene.h"
+#include "core/factories/sprite_factory.h"
+
+namespace engine {
+
+class PacketHandler {
+public:
+  PacketHandler(Scene* scene, size_t local_player_id, const SpriteFactory* sprite_factory);
+  ~PacketHandler() = default;
+  
+  void HandlePacket(Packet& packet);
+  
+private:
+  Scene* _scene;
+  size_t _local_player_id;
+  const SpriteFactory* _sprite_factory;
+  
+  void HandleWorldSnapshot(Packet& packet);
+  void HandleEntityCreateResponse(Packet& packet);
+};
+
+} // namespace engine
+
+#endif // PACKET_HANDLER_H

--- a/include/scene/scene.h
+++ b/include/scene/scene.h
@@ -2,6 +2,7 @@
 #define SCENE_H
 
 #include <string>
+#include <functional>
 
 #include "entities/entities.h"
 #include "entities/entity_manager.h"
@@ -35,7 +36,7 @@ public:
     
     Packet request(PacketType::ENTITY_CREATE_REQUEST);
     request.Write(entity->GetPos());
-    request.WriteString(entity->GetSpritePath());
+    request.Write(entity->GetSpriteTextureId());
     Client::GetInstance().Send(request);
     
     Packet response = Client::GetInstance().Receive();
@@ -56,6 +57,11 @@ public:
   Packet GenerateWorldSnapshot() const;
   
   void ApplyWorldSnapshot(Packet& snapshot, size_t ignore_entity_id = 0);
+  
+  void ApplyNewEntitySnapshot(
+      Packet& snapshot, 
+      size_t ignore_entity_id,
+      std::function<std::unique_ptr<Sprite>(int)> sprite_factory);
   
 private:
   std::unique_ptr<EntityManager> _entity_manager;

--- a/src/core/engine/engine.cpp
+++ b/src/core/engine/engine.cpp
@@ -1,4 +1,5 @@
 #include "core/engine/engine.h"
+#include "networking/packet_handler.h"
 #include "raylib.h"
 
 namespace engine {
@@ -48,14 +49,16 @@ void Engine::Run()
 
 void Engine::RunGame() 
 {
+  PacketHandler packet_handler(_loaded_scene.get(), _local_player_id, &_sprite_factory);
+  
   while (!WindowShouldClose()) {
     float dt = GetFrameTime();
 
     if (_config.mode == CLIENT && _loaded_scene) {
       Packet packet = Client::GetInstance().ReceiveNonBlocking();
-      if (packet._type == PacketType::WORLD_SNAPSHOT) {
-        _loaded_scene->ApplyWorldSnapshot(packet, _local_player_id);
-      } 
+      if (packet._type != PacketType::NONE) {
+        packet_handler.HandlePacket(packet);
+      }
     }
 
     if (_loaded_scene) {

--- a/src/core/sprite/sprite.cpp
+++ b/src/core/sprite/sprite.cpp
@@ -23,6 +23,12 @@ Sprite::Sprite(Texture2D texture, const char* path)
     _path(path)
 {}
 
+Sprite::Sprite(int texture_id)
+  : _texture_id(texture_id),
+    _loaded(false),
+    _path(nullptr)
+{}
+
 Sprite::~Sprite()
 {
   if (_loaded) 
@@ -88,6 +94,11 @@ void Sprite::Draw(Rectangle frame_rec, Vector2 pos) const
 const char* Sprite::GetPath() const
 {
   return _path;
+}
+
+int Sprite::GetTextureId() const
+{
+  return _texture_id;
 }
 
 } // namespace engine

--- a/src/entities/entities.cpp
+++ b/src/entities/entities.cpp
@@ -40,11 +40,8 @@ void Entity::Update(float dt)
 
 void Entity::Draw() const 
 {
-  if (_sprite) {
+  if (_sprite) 
     _sprite->Draw(_pos);
-  } else {
-    // Entité sans sprite (probablement côté serveur)
-  }
 }
 
 size_t Entity::GetId() const
@@ -61,6 +58,12 @@ const char* Entity::GetSpritePath() const
 {
   if (!_sprite) return nullptr;
   return _sprite->GetPath();
+}
+
+int Entity::GetSpriteTextureId() const
+{
+  if (!_sprite) return 0;
+  return _sprite->GetTextureId();
 }
   
 void Entity::LoadSprite() const

--- a/src/networking/packet_handler.cpp
+++ b/src/networking/packet_handler.cpp
@@ -1,0 +1,45 @@
+#include "networking/packet_handler.h"
+
+namespace engine {
+
+PacketHandler::PacketHandler(
+    Scene* scene, 
+    size_t local_player_id, 
+    const SpriteFactory* sprite_factory)
+  : _scene(scene),
+    _local_player_id(local_player_id),
+    _sprite_factory(sprite_factory)
+{}
+
+void PacketHandler::HandlePacket(Packet& packet)
+{
+  switch (packet._type) {
+    case PacketType::WORLD_SNAPSHOT:
+      HandleWorldSnapshot(packet);
+      break;
+    case PacketType::ENTITY_CREATE_RESPONSE:
+      HandleEntityCreateResponse(packet);
+      break;
+    default:
+      break;
+  }
+}
+
+void PacketHandler::HandleWorldSnapshot(Packet& packet)
+{
+  if (_scene) {
+    _scene->ApplyWorldSnapshot(packet, _local_player_id);
+  }
+}
+
+void PacketHandler::HandleEntityCreateResponse(Packet& packet)
+{
+  if (_scene && _sprite_factory && _sprite_factory->IsInitialized()) {
+    auto factory_fn = [this](int texture_id) {
+      return _sprite_factory->CreateSprite(texture_id);
+    };
+    _scene->ApplyNewEntitySnapshot(packet, _local_player_id, factory_fn);
+  }
+}
+
+} // namespace engine

--- a/src/networking/server.cpp
+++ b/src/networking/server.cpp
@@ -84,28 +84,26 @@ void Server::HandlePacket(int client_socket, Packet& packet, Scene* scene)
 {
   switch (packet._type) {
     case PacketType::ENTITY_CREATE_REQUEST: {
-      std::cout << "DEBUG: Received ENTITY_CREATE_REQUEST, packet size: " 
-                << packet.GetSize() << " bytes" << std::endl;
-      
       Vector2 position;
+      int texture_id;
       packet.Read(position);
-      std::string path = packet.ReadString();
+      packet.Read(texture_id);
       
       size_t entity_id = GenerateEntityId();
       
       scene->AddEntity(std::make_unique<Entity>(
-            std::make_unique<Sprite>(path),
+            std::make_unique<Sprite>(texture_id),
             position, 
             entity_id));
       
       Packet response(PacketType::ENTITY_CREATE_RESPONSE);
       response.Write(entity_id);
-      response.WriteString(path);
-      Send(client_socket, response);
+      response.Write(texture_id);
+      BroadcastSnapshot(_connected_clients, response);
       
       std::cout << "Entity created with ID: " << entity_id << " at position { " 
                 << position.x << ":" << position.y << " }" 
-                << " with sprite: " << path << std::endl;
+                << " with texture id: " << texture_id << std::endl;
       break;
     }
     

--- a/src/scene/scene.cpp
+++ b/src/scene/scene.cpp
@@ -94,4 +94,27 @@ void Scene::ApplyWorldSnapshot(Packet& snapshot, size_t ignore_entity_id)
   }
 }
 
+void Scene::ApplyNewEntitySnapshot(
+    Packet& snapshot, 
+    size_t ignore_entity_id,
+    std::function<std::unique_ptr<Sprite>(int)> sprite_factory)
+{
+  if (!_entity_manager) return;
+
+  size_t entity_id;
+  int texture_id;
+  Vector2 pos;
+
+  snapshot.Read(entity_id);
+  snapshot.Read(texture_id);
+  snapshot.Read(pos);
+
+  if (entity_id == ignore_entity_id) return;
+
+  auto sprite = sprite_factory(texture_id);
+  if (sprite) {
+    AddEntity<Entity>(std::move(sprite), pos, entity_id);
+  }
+}
+
 } // namespace engine


### PR DESCRIPTION
- add assets registry that loads all textures and keep them so they can be access at runtime 
- improve sprite creation by adding sprite_factory
- send global sprite information on client registration so server can tell other client and make each client able to chose its own sprite 
- refactor global packet workflow by adding packet_handler class hence making global packet workflow more extensible and readable limit engine responsability a bit to respect SOLID principle as much as possible 
- add lambda function to read program arguments for QoL