### PR TITLE
FEAT - server scheduler

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,13 +16,16 @@ SHABBY_LIB_SRC = \
 	$(SRC)/scene/scene.cpp \
 	$(SRC)/networking/server.cpp \
 	$(SRC)/networking/network_manager.cpp \
-	$(SRC)/networking/packet_handler.cpp 
+	$(SRC)/networking/packet_handler.cpp \
+	$(SRC)/core/scheduler/scheduler.cpp \
+	$(SRC)/core/game_simulation/game_simulation.cpp
 
 EXAMPLE_SRC = \
 	$(EXAMPLE)/main.cpp \
 	$(EXAMPLE)/game/player.cpp \
 	$(EXAMPLE)/game/main_scene.cpp \
-	$(EXAMPLE)/game/ennemy.cpp
+	$(EXAMPLE)/game/ennemy.cpp \
+	$(EXAMPLE)/example_logic.cpp
 
 SHABBY_LIB_OBJ = \
 	$(BUILD)/entities/entities.o \
@@ -35,13 +38,16 @@ SHABBY_LIB_OBJ = \
 	$(BUILD)/scene/scene.o \
 	$(BUILD)/networking/server.o \
 	$(BUILD)/networking/network_manager.o \
-	$(BUILD)/networking/packet_handler.o 
+	$(BUILD)/networking/packet_handler.o \
+	$(BUILD)/core/scheduler/scheduler.o \
+	$(BUILD)/core/game_simulation/game_simulation.o
 
 
 EXAMPLE_OBJ = \
 	$(BUILD)/main.o \
 	$(BUILD)/game/player.o \
-	$(BUILD)/game/main_scene.o 
+	$(BUILD)/game/main_scene.o \
+	$(BUILD)/example_logic.o
 
 CXX = g++
 

--- a/example/example_logic.cpp
+++ b/example/example_logic.cpp
@@ -1,0 +1,24 @@
+#include "example_logic.h"
+
+void ExampleLogic::OnStart(engine::GameSimulation& sim) 
+{
+  sim.SetEntityFactory([](engine::Scene* scene, std::function<size_t()>& id_gen) {
+    static std::random_device rd;
+    static std::mt19937 gen(rd());
+    static std::uniform_real_distribution<float> dist_x(50.0f, 750.0f);
+    static std::uniform_real_distribution<float> dist_y(50.0f, 400.0f);
+    
+    size_t entity_id = id_gen();
+    Vector2 position = {dist_x(gen), dist_y(gen)};
+    int texture_id = 0;
+    
+    scene->AddEntity(std::make_unique<engine::Entity>(
+        std::make_unique<engine::AnimatedSprite>(texture_id, 4, 1, 3),
+        position,
+        entity_id));
+  });
+
+  sim._scheduler->Every(4.f, [&sim]() {
+      sim.AddEntity();
+  });
+}

--- a/example/example_logic.h
+++ b/example/example_logic.h
@@ -1,0 +1,15 @@
+#ifndef EXAMPLE_LOGIC_H
+#define EXAMPLE_LOGIC_H
+
+#include "networking/server_logic.h"
+#include "core/game_simulation/game_simulation.h"
+#include "game/player.h"
+#include <random>
+
+
+class ExampleLogic : public engine::ServerLogic {
+public:
+  void OnStart(engine::GameSimulation& sim) override;
+};
+
+#endif // EXAMPLE_LOGIC_H

--- a/example/main.cpp
+++ b/example/main.cpp
@@ -2,6 +2,8 @@
 #include "game/player.h"
 #include "game/main_scene.h"
 #include "core/assets/assets_registry.h"
+#include "networking/server.h"
+#include "example_logic.h"
 #include <memory>
 
 enum class TextureId
@@ -9,6 +11,63 @@ enum class TextureId
   Monkey,
   Monk
 };
+
+void RunServerEngine()
+{
+  engine::ServerConf conf{8080, 2};
+  std::unique_ptr<engine::ServerLogic> logic = 
+    std::make_unique<ExampleLogic>();
+  engine::Engine engine(conf, std::move(logic));
+  engine.Run();
+}
+
+void RunClientEngine() 
+{
+  engine::EngineConfig config{
+    800,
+    450,
+    "shabby",
+    engine::CLIENT,
+  };  
+
+  engine::Engine engine(config);
+  auto& registry = engine.GetAssetRegistry<TextureId>();
+  registry.LoadAll(
+      engine::AssetDesc<TextureId> { 
+      TextureId::Monkey, 
+      "assets/actors/monkey/Idle.png",
+      4, 1},
+      engine::AssetDesc<TextureId> { 
+      TextureId::Monk, 
+      "assets/actors/monk/Idle.png",
+      6, 1}
+      );
+
+  engine.SetSpriteFactory<TextureId>(
+      [](
+        engine::AssetRegistry<TextureId>& reg, int texture_id) 
+      -> std::unique_ptr<engine::Sprite> 
+      {
+        TextureId asset_id = static_cast<TextureId>(texture_id);
+        int cols = reg.GetTextureCols(asset_id);
+        int rows = reg.GetTextureRows(asset_id);
+        return std::make_unique<engine::AnimatedSprite>(
+            reg, asset_id, cols, rows, 3);
+      }
+  );
+
+  auto scene = std::make_unique<game::MainScene>();
+  size_t player_id;
+
+  player_id = scene->AddEntityWithServerId<game::Player>(
+      std::make_unique<engine::AnimatedSprite>
+      (registry, TextureId::Monk, 6, 1, 3),
+      Vector2{100.0f, 100.0f});
+
+  engine.SetLocalPlayerId(player_id);
+  engine.LoadScene(std::move(scene));
+  engine.Run();
+}
 
 int main(int argc, char* argv[]) 
 {
@@ -21,77 +80,12 @@ int main(int argc, char* argv[])
     return false;
   };
 
-  engine::EngineConfig config{
-    800,
-    450,
-    "shabby",
-    engine::STANDALONE,
-  };  
-
-  if (argc > 1) {
-    if (has_arg("server"))
-     config.mode = engine::SERVER;
-    if (has_arg("client"))
-      config.mode = engine::CLIENT;
+  if (has_arg("client")) {
+    RunClientEngine();
   }
-
-  engine::Engine engine(config);
-
-  if (config.mode != engine::SERVER) {
-    auto& registry = engine.GetAssetRegistry<TextureId>();
-    registry.LoadAll(
-        engine::AssetDesc<TextureId> { 
-          TextureId::Monkey, 
-          "assets/actors/monkey/Idle.png",
-          4, 1},
-        engine::AssetDesc<TextureId> { 
-          TextureId::Monk, 
-          "assets/actors/monk/Idle.png",
-          6, 1}
-    );
-
-    engine.SetSpriteFactory<TextureId>(
-      [](
-        engine::AssetRegistry<TextureId>& reg, int texture_id) 
-          -> std::unique_ptr<engine::Sprite> 
-      {
-        const char* path = 
-          reg.GetTexturePath(static_cast<TextureId>(texture_id));
-        int cols = 
-          reg.GetTextureCols(static_cast<TextureId>(texture_id));
-        int rows = 
-          reg.GetTextureRows(static_cast<TextureId>(texture_id));
-        return std::make_unique<engine::AnimatedSprite>(
-            path, cols, rows, 3);
-      }
-    );
-
-    auto scene = std::make_unique<game::MainScene>();
-    size_t player_id;
-
-    if (has_arg("2")) {
-      player_id = scene->AddEntityWithServerId<game::Player>(
-          std::make_unique<engine::AnimatedSprite>
-          (registry, TextureId::Monkey, 4, 1, 3),
-          Vector2{100.0f, 100.0f});
-    } else {
-      player_id = scene->AddEntityWithServerId<game::Player>(
-          std::make_unique<engine::AnimatedSprite>
-          (registry, TextureId::Monk, 6, 1, 3),
-          Vector2{100.0f, 100.0f});
-    }
-
-    engine.SetLocalPlayerId(player_id);
-    engine.LoadScene(std::move(scene));
+  else if (has_arg("server")) {
+    RunServerEngine();
   }
-  else {
-    auto scene = std::make_unique<game::MainScene>();
-
-    engine.LoadScene(std::move(scene));
-  }
-  
-  engine.Run();
   
   return 0;
 }
-

--- a/include/core/engine/engine.h
+++ b/include/core/engine/engine.h
@@ -9,6 +9,8 @@
 #include "networking/network_manager.h"
 #include "core/assets/assets_registry.h"
 #include "core/factories/sprite_factory.h"
+#include "networking/packet_handler.h"
+#include "raylib.h"
 
 namespace engine {
 
@@ -20,15 +22,18 @@ enum EngineMode {
 };
 
 struct EngineConfig {
-  int width;
-  int height;
-  const char* title;
+  int width = 0;
+  int height = 0;
+  const char* title = "";
   EngineMode mode = STANDALONE;
 };
 
 class Engine {
 public:
   explicit Engine(const EngineConfig& config);
+  explicit Engine(
+      const ServerConf& server_config,
+      std::unique_ptr<ServerLogic> logic);
   ~Engine();
   
   Engine(const Engine&) = delete;
@@ -69,9 +74,11 @@ public:
   
 private:
   EngineConfig _config;
+
   std::shared_ptr<void> _assets_registry;
   std::type_index _assets_registry_type{typeid(void)};
   SpriteFactory _sprite_factory;
+
   std::unique_ptr<Scene> _loaded_scene;
   std::unique_ptr<NetworkManager> _network_manager;
   bool _initialized;

--- a/include/core/game_simulation/game_simulation.h
+++ b/include/core/game_simulation/game_simulation.h
@@ -1,0 +1,32 @@
+#ifndef GAME_SIMULATION_H
+#define GAME_SIMULATION_H
+
+#include "core/sprite/sprite.h"
+#include "scene/scene.h"
+#include "core/scheduler/scheduler.h"
+#include <memory>
+#include <functional>
+#include <random>
+
+namespace engine {
+
+class GameSimulation {
+public:
+  explicit GameSimulation(std::unique_ptr<Scene> scene);
+  ~GameSimulation() = default;
+
+  void Update(float dt);
+  void AddEntity();
+  void SetEntityIdGenerator(std::function<size_t()> generator);
+  void SetEntityFactory(std::function<void(Scene*, std::function<size_t()>&)> factory);
+  Scene* GetScene() const { return _scene.get(); }
+  std::unique_ptr<Scheduler> _scheduler;
+private:
+  std::unique_ptr<Scene> _scene;
+  std::function<size_t()> _entity_id_generator;
+  std::function<void(Scene*, std::function<size_t()>&)> _entity_factory;
+};
+
+} // namespace engine
+
+#endif // GAME_SIMULATION_H

--- a/include/core/scheduler/scheduler.h
+++ b/include/core/scheduler/scheduler.h
@@ -1,0 +1,31 @@
+#ifndef SCHEDULER_H
+#define SCHEDULER_H
+
+#include <functional>
+
+namespace engine {
+
+struct ScheduledTask;
+
+class Scheduler {
+public:
+  using Task = std::function<void()>;
+  
+  void Every(float seconds, Task task);
+  void After(float seconds, Task task);
+  void Update(float dt);
+private:
+  std::vector<ScheduledTask> tasks;
+};
+
+struct ScheduledTask {
+  float timer;
+  float interval;
+  bool repeat;
+  Scheduler::Task task;
+};
+
+
+} // namespace engine
+
+#endif // SCHEDULER_H

--- a/include/core/sprite/animated_sprite.h
+++ b/include/core/sprite/animated_sprite.h
@@ -21,6 +21,14 @@ public:
       int rows,
       float frame_speed);
 
+  explicit AnimatedSprite(
+    int texture_id, 
+    int cols,
+    int rows,
+    float frame_speed
+  );
+
+
   template<typename T>
   explicit AnimatedSprite(
        AssetRegistry<T> registry,

--- a/include/core/sprite/sprite.h
+++ b/include/core/sprite/sprite.h
@@ -23,7 +23,8 @@ public:
   : _texture(registry.GetTexture(asset_id)),
     _texture_id(static_cast<int>(asset_id)),
     _loaded(true),
-    _path(registry.GetTexturePath(asset_id))
+    _owns_texture(false),
+    _path(nullptr)
   {}
 
   virtual ~Sprite(); 
@@ -50,6 +51,7 @@ private:
   Texture2D _texture;
   int _texture_id = 0;
   bool _loaded;
+  bool _owns_texture = true;
   const char* _path;
 };
 

--- a/include/entities/entity_manager.h
+++ b/include/entities/entity_manager.h
@@ -27,6 +27,7 @@ public:
   void UpdateAll(float dt);
   void DrawAll() const;
   void UpdatePosition(size_t id, Vector2 pos);
+  void UpdateEntityId(size_t old_id, size_t new_id);
 
   const std::vector<std::unique_ptr<Entity>>& GetEntities() const { return _entities; }
   

--- a/include/networking/network_manager.h
+++ b/include/networking/network_manager.h
@@ -3,6 +3,7 @@
 
 #include "networking/server.h"
 #include "networking/client.h"
+#include "networking/server_logic.h"
 #include "scene/scene.h"
 
 namespace engine {
@@ -12,8 +13,11 @@ public:
   explicit NetworkManager();
   ~NetworkManager();
 
-  void InitServer(ServerConf _conf);
-  void RunServer(std::unique_ptr<Scene> scene);
+  void InitServer(
+      ServerConf _conf, 
+      std::unique_ptr<ServerLogic> logic,
+      std::unique_ptr<Scene> scene);
+  void RunServer();
 
   void InitClient();
 private:

--- a/include/networking/server.h
+++ b/include/networking/server.h
@@ -5,6 +5,9 @@
 #include "networking/packet.h"
 #include "raylib.h"
 #include "replication/snapshot/entity_snapshot.h"
+#include "core/scheduler/scheduler.h"
+#include "networking/server_logic.h"
+#include "core/game_simulation/game_simulation.h"
 
 #include <memory>
 #include <netinet/in.h>
@@ -25,10 +28,13 @@ struct ServerConf {
 
 class Server {
 public:
-  explicit Server(ServerConf conf);  
+  explicit Server(
+      ServerConf conf, 
+      std::unique_ptr<ServerLogic> logic,
+      std::unique_ptr<Scene> scene);
   ~Server();
 
-  void Run(std::unique_ptr<Scene> scene);
+  void Run();
   Packet Receive(int client_socket);
   Packet ReceiveNonBlocking(int client_socket);
   void Send(int client_socket, Packet packet);
@@ -41,6 +47,8 @@ private:
   ServerConf _conf;
   size_t _next_entity_id = 1;
   std::vector<int> _connected_clients;
+  std::unique_ptr<ServerLogic> _logic;
+  std::unique_ptr<GameSimulation> _game_simulation;
 };
 
 } // namespace engine

--- a/include/networking/server_logic.h
+++ b/include/networking/server_logic.h
@@ -1,0 +1,18 @@
+#ifndef SERVER_LOGIC_H
+#define SERVER_LOGIC_H
+
+#include "core/game_simulation/game_simulation.h"
+
+namespace engine {
+
+class ServerLogic {
+public:
+  virtual ~ServerLogic() = default;
+
+  virtual void OnStart([[maybe_unused]] GameSimulation& sim) {};
+  virtual void OnUpdate([[maybe_unused]] GameSimulation& sim) {};
+};
+
+} // namespace engine
+
+#endif // SERVER_LOGIC_H

--- a/include/scene/scene.h
+++ b/include/scene/scene.h
@@ -54,25 +54,29 @@ public:
   {
     auto entity = std::make_unique<T>(std::forward<Args>(args)...);
     
+    size_t temp_id = 0;
+    entity->SetId(temp_id);
+    AddEntity(std::move(entity));
+    
     Packet request(PacketType::ENTITY_CREATE_REQUEST);
-    request.Write(entity->GetPos());
-    request.Write(entity->GetSpriteTextureId());
+    request.Write(_entity_manager->GetEntities().back()->GetPos());
+    request.Write(_entity_manager->GetEntities().back()->GetSpriteTextureId());
     Client::GetInstance().Send(request);
     
     Packet response = Client::GetInstance().Receive();
     size_t server_id = 0;
     if (response._type == PacketType::ENTITY_CREATE_RESPONSE) {
       response.Read(server_id);
-      entity->SetId(server_id);
+      UpdateEntityId(temp_id, server_id);
     }
     
-    AddEntity(std::move(entity));
     return server_id;
   }
 
   void UpdateScene(float dt);
   void DrawScene() const;
   void ApplySnapshot(Snapshot& s);
+  void UpdateEntityId(size_t old_id, size_t new_id);
 
   Packet GenerateWorldSnapshot() const;
 

--- a/src/core/game_simulation/game_simulation.cpp
+++ b/src/core/game_simulation/game_simulation.cpp
@@ -1,0 +1,37 @@
+#include "core/game_simulation/game_simulation.h"
+#include "core/sprite/sprite.h"
+#include <random>
+
+namespace engine {
+
+GameSimulation::GameSimulation(std::unique_ptr<Scene> scene)
+  : _scheduler(std::make_unique<Scheduler>()),
+    _scene(std::move(scene)),
+    _entity_id_generator(nullptr),
+    _entity_factory(nullptr)
+{}
+
+void GameSimulation::Update(float dt)
+{
+  if (_scheduler)
+    _scheduler->Update(dt);
+}
+
+void GameSimulation::SetEntityIdGenerator(std::function<size_t()> generator)
+{
+  _entity_id_generator = generator;
+}
+
+void GameSimulation::SetEntityFactory(std::function<void(Scene*, std::function<size_t()>&)> factory)
+{
+  _entity_factory = factory;
+}
+
+void GameSimulation::AddEntity()
+{
+  if (_entity_factory && _scene && _entity_id_generator) {
+    _entity_factory(_scene.get(), _entity_id_generator);
+  }
+}
+
+} // namespace engine

--- a/src/core/scheduler/scheduler.cpp
+++ b/src/core/scheduler/scheduler.cpp
@@ -1,0 +1,27 @@
+#include "core/scheduler/scheduler.h"
+
+namespace engine {
+
+void Scheduler::Every(float seconds, Task task)
+{
+  tasks.push_back(ScheduledTask{seconds, seconds, true, task}); 
+}
+
+void Scheduler::After(float seconds, Task task)
+{
+  tasks.push_back(ScheduledTask{seconds, 0.f, false, task});
+}
+
+void Scheduler::Update(float dt)
+{
+  for (auto& t : tasks) {
+    t.timer -= dt; 
+    if (t.timer < 0.f) {
+      t.task();  
+      if (t.repeat)
+        t.timer = t.interval;
+    }
+  }  
+}
+
+} // namespace engine

--- a/src/core/sprite/animated_sprite.cpp
+++ b/src/core/sprite/animated_sprite.cpp
@@ -26,9 +26,22 @@ AnimatedSprite::AnimatedSprite(
     _frame_rec{0.0f, 0.0f, 0.0f, 0.0f}
 {}
 
+AnimatedSprite::AnimatedSprite(
+    int texture_id, 
+    int cols,
+    int rows,
+    float frame_speed)
+  : Sprite(texture_id),
+    _cols(cols),
+    _rows(rows),
+    _frame_speed(frame_speed),
+    _frame_rec{0.0f, 0.0f, 0.0f, 0.0f}
+{}  
+
 void AnimatedSprite::Load()
 {
   Sprite::Load();
+  
   _frame_rec.width = static_cast<float>(GetTexture().width) / _cols;
   _frame_rec.height = static_cast<float>(GetTexture().height);
 }

--- a/src/core/sprite/sprite.cpp
+++ b/src/core/sprite/sprite.cpp
@@ -31,30 +31,33 @@ Sprite::Sprite(int texture_id)
 
 Sprite::~Sprite()
 {
-  if (_loaded) 
+  if (_loaded && _owns_texture) 
     UnloadTexture(_texture);
 }
 
 Sprite::Sprite(Sprite&& other) noexcept 
   : _texture(other._texture), 
     _loaded(other._loaded),
+    _owns_texture(other._owns_texture),
     _path(other._path)
 {
   other._loaded = false;
+  other._owns_texture = false;
   other._path = nullptr;
 }
 
 Sprite& Sprite::operator=(Sprite&& other) noexcept 
 {
   if (this != &other) {
-    if (_loaded) 
+    if (_loaded && _owns_texture) 
       UnloadTexture(_texture);
 
     _texture = other._texture;
     _loaded = other._loaded;
-    _path = other._path;
+    _owns_texture = other._owns_texture;
     _path = other._path;
     other._loaded = false;
+    other._owns_texture = false;
     other._path = nullptr;
   }
   return *this;
@@ -63,6 +66,9 @@ Sprite& Sprite::operator=(Sprite&& other) noexcept
 void Sprite::Load()
 {
   if (_loaded) {
+    return;
+  }
+  if (_path == nullptr) {
     return;
   }
   _texture = LoadTexture(_path);

--- a/src/entities/entities.cpp
+++ b/src/entities/entities.cpp
@@ -68,7 +68,7 @@ int Entity::GetSpriteTextureId() const
   
 void Entity::LoadSprite() const
 {
-  if (_sprite && _sprite->GetPath() != nullptr) {
+  if (_sprite) {
     _sprite->Load();
   }
 }

--- a/src/entities/entity_manager.cpp
+++ b/src/entities/entity_manager.cpp
@@ -41,5 +41,13 @@ void EntityManager::UpdatePosition(size_t id, Vector2 pos)
     }
   }
 }
-
+void EntityManager::UpdateEntityId(size_t old_id, size_t new_id)
+{
+  for (auto& e : _entities) {
+    if (e->GetId() == old_id) {
+      e->SetId(new_id);
+      return;
+    }
+  }
+}
 } // namespace engine

--- a/src/networking/network_manager.cpp
+++ b/src/networking/network_manager.cpp
@@ -8,15 +8,19 @@ NetworkManager::NetworkManager()
 NetworkManager::~NetworkManager()
 {}
 
-void NetworkManager::InitServer(ServerConf conf)
+void NetworkManager::InitServer(
+    ServerConf conf, 
+    std::unique_ptr<ServerLogic> logic,
+    std::unique_ptr<Scene> scene)
 {
-  _server = std::make_unique<Server>(conf);
+  _server = std::make_unique<Server>(
+      conf, std::move(logic), std::move(scene));
 }
 
-void NetworkManager::RunServer(std::unique_ptr<Scene> scene) 
+void NetworkManager::RunServer() 
 {
   if (_server)
-    _server->Run(std::move(scene));
+    _server->Run();
 }
 
 void NetworkManager::InitClient() 

--- a/src/scene/scene.cpp
+++ b/src/scene/scene.cpp
@@ -42,6 +42,13 @@ void Scene::ApplySnapshot(Snapshot& s)
   }
 }
 
+void Scene::UpdateEntityId(size_t old_id, size_t new_id)
+{
+  if (_entity_manager) {
+    _entity_manager->UpdateEntityId(old_id, new_id);
+  }
+}
+
 Packet Scene::GenerateWorldSnapshot() const
 {
   Packet snapshot(PacketType::WORLD_SNAPSHOT);


### PR DESCRIPTION
- add server scheduler that execute task on dev demand
- refactor server game simulation by adding a GameSimulation class that contains the scene instead of the server itself
- refactor global server - client creation workflow to make api easier to use
- add serverLogic to allow dev to set rules for the game to execute
- enhance global sprite handling for server side engine
- remove race condition linked by the fact client was waiting to long for the server to send id back